### PR TITLE
Added support for generic messages

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ function plugin (Vue, options = {}) {
   Vue.prototype.$vuelidateErrorExtractor = {
     i18n: options.i18n || false,
     messages: options.messages || {},
+    genericMessages: options.genericMessages || [],
     validationKeys: options.validationKeys || {}
   }
   if (typeof options.template === 'undefined') {

--- a/src/message-extractor-mixin.js
+++ b/src/message-extractor-mixin.js
@@ -54,12 +54,12 @@ export default {
     getPlainMessage (key, properties) {
       const msg = get(key, this.mergedMessages, false)
       if (!msg) {
-        const matchingKeys = Object.keys(this.mergedMessages).filter(function (messageKey) {
-          return new RegExp(messageKey).test(key)
+        const matchingConfigs = this.$vuelidateErrorExtractor.genericMessages.filter(function (config) {
+          return config.regexp.test(key)
         })
 
-        if (matchingKeys.length) {
-          return template(this.mergedMessages[matchingKeys[0]], properties)
+        if (matchingConfigs.length) {
+          return template(this.mergedMessages[matchingConfigs[0].message], properties)
         } else {
           return key
         }

--- a/src/message-extractor-mixin.js
+++ b/src/message-extractor-mixin.js
@@ -59,7 +59,7 @@ export default {
         })
 
         if (matchingConfigs.length) {
-          return template(this.mergedMessages[matchingConfigs[0].message], properties)
+          return template(matchingConfigs[0].message, properties)
         } else {
           return key
         }

--- a/src/message-extractor-mixin.js
+++ b/src/message-extractor-mixin.js
@@ -54,7 +54,15 @@ export default {
     getPlainMessage (key, properties) {
       const msg = get(key, this.mergedMessages, false)
       if (!msg) {
-        return key
+        const matchingKeys = Object.keys(this.mergedMessages).filter(function (messageKey) {
+          return new RegExp(messageKey).test(key)
+        })
+
+        if (matchingKeys.length) {
+          return template(this.mergedMessages[matchingKeys[0]], properties)
+        } else {
+          return key
+        }
       }
       return template(msg, properties)
     }

--- a/src/utils.js
+++ b/src/utils.js
@@ -20,7 +20,7 @@ export function get (string, object, fallback = '') {
   }
 
   try {
-    return string.split('.').reduce((obj, current) => obj[current] || '', object)
+    return string.split('.').reduce((obj, current) => obj.hasOwnProperty(current) ? obj[current] : '', object)
   } catch (err) {
     idDev && console.warn(`[vuelidate-error-extractor]: ${err}`)
     return fallback
@@ -43,7 +43,7 @@ export function template (template, object) {
   }
   const regx = /{(.*?)}/g
 
-  return template.replace(regx, (_, key) => get(key, object) || '')
+  return template.replace(regx, (_, key) => get(key, object))
 }
 
 /**

--- a/test/helpers/entry.js
+++ b/test/helpers/entry.js
@@ -8,7 +8,11 @@ Vue.use(VueI18n)
 Vue.config.productionTip = false
 Vue.use(vuelidate)
 Vue.use(vuelidateErrorExtractor, {
-  template: templates.foundation6
+  template: templates.foundation6,
+  messages: {
+    required: '{attribute} is required',
+    '.+': '{attribute} has an error'
+  }
 })
 
 window.Vue = Vue

--- a/test/helpers/entry.js
+++ b/test/helpers/entry.js
@@ -10,9 +10,12 @@ Vue.use(vuelidate)
 Vue.use(vuelidateErrorExtractor, {
   template: templates.foundation6,
   messages: {
-    required: '{attribute} is required',
-    '.+': '{attribute} has an error'
-  }
+    required: '{attribute} is required'
+  },
+  genericMessages: [{
+    regexp: /.+/,
+    message: '{attribute} has an error'
+  }]
 })
 
 window.Vue = Vue

--- a/test/unit/add.test.js
+++ b/test/unit/add.test.js
@@ -57,14 +57,6 @@ describe('Test extractor with vue-i18n', () => {
       }).then(done)
     })
 
-    it('should have correct error message', done => {
-      vm.$v.$touch()
-      vm.text = ''
-      nextTick(() => {
-        expect(vm.$el.querySelector('.form-error').textContent).to.equal('Field text is required')
-      }).then(done)
-    })
-
     it('should have 1 error message for required', done => {
       vm.$v.$touch()
       vm.text = ''

--- a/test/unit/add.test.js
+++ b/test/unit/add.test.js
@@ -1,8 +1,11 @@
 import Vue from 'vue'
-import { required } from 'vuelidate/lib/validators'
+import { required, minLength } from 'vuelidate/lib/validators'
 import VueI18n from 'vue-i18n'
+import chai from 'chai'
 
-describe('Test extractor', () => {
+const expect = chai.expect
+
+describe('Test extractor with vue-i18n', () => {
   let vm
   const messages = {
     en: {
@@ -22,7 +25,9 @@ describe('Test extractor', () => {
       template: '<div><form-group :validator="$v.text" label="text"><input class="__input" v-model="text"/></form-group></div>',
       data: { text: 'stuff' },
       validations: {
-        text: { required }
+        text: {
+          required
+        }
       }
     }).$mount()
   })
@@ -52,12 +57,62 @@ describe('Test extractor', () => {
       }).then(done)
     })
 
+    it('should have correct error message', done => {
+      vm.$v.$touch()
+      vm.text = ''
+      nextTick(() => {
+        expect(vm.$el.querySelector('.form-error').textContent).to.equal('Field text is required')
+      }).then(done)
+    })
+
     it('should have 1 error message for required', done => {
       vm.$v.$touch()
       vm.text = ''
       nextTick(() => {
-        expect(vm.$el.querySelector('.form-error').childNodes.length).to.equal(1)
-        expect(vm.$el.querySelector('.form-error').childNodes[0].dataset.validationAttr).to.equal('required')
+        expect(vm.$el.querySelector('.form-error').childNodes.length).to.equal(2)
+        expect(vm.$el.querySelector('.form-error').childNodes[1].dataset.validationAttr).to.equal('required')
+      }).then(done)
+    })
+  })
+})
+
+describe('Test extractor without vue-i18n', () => {
+  let vm
+
+  beforeEach(() => {
+    vm = new Vue({
+      template: '<div><form-group :validator="$v.text" label="text"><input class="__input" v-model="text"/></form-group></div>',
+      data: { text: 'stuff' },
+      validations: {
+        text: {
+          required,
+          foo: minLength(3)
+        }
+      }
+    }).$mount()
+  })
+
+  describe('formGroup element', () => {
+    it('should mount', done => {
+      nextTick(() => {
+        console.log(vm.$el)
+        expect(vm.$el.querySelector('.form-group')).to.exist
+      }).then(done)
+    })
+
+    it('should match regexp keys if no direct message found', done => {
+      vm.$v.$touch()
+      vm.text = ''
+      nextTick(() => {
+        expect(vm.$el.querySelector('.form-error').textContent).to.equal('text is required')
+      }).then(done)
+    })
+
+    it('should match regexp keys if no direct message found', done => {
+      vm.$v.$touch()
+      vm.text = 'ab'
+      nextTick(() => {
+        expect(vm.$el.querySelector('.form-error').textContent).to.equal('text has an error')
       }).then(done)
     })
   })


### PR DESCRIPTION
I have added support for defining messages for generated validator names.

This will only be used if the validator does have no exactly matching message.

You define them like this:
```js
Vue.use(vuelidateErrorExtractor, {
  template: templates.foundation6,
  messages: {
    required: '{attribute} is required'
  },
  genericMessages: [{
    regexp: /.+/,
    message: '{attribute} has an error'
  }]
})
```

I tried to add testcases, but seems they are not running properly anyway, so did some changes to make them run.

Would you be willing to add something like this? My inspiration is this issue in my plugin: https://github.com/mokkabonna/vue-vuelidate-jsonschema/issues/4

Then I could define my generic messages like this:

```js
Vue.use(vuelidateErrorExtractor, {
  template: templates.foundation6,
  messages: {
    required: '{attribute} is required'
  },
  genericMessages: [{
    regexp: /^schemaPattern(\d+)?$/,
    message: '{schema.title} does not match pattern {schema.pattern}'
  }]
})
```

The first message to match the related regexp would be used.

This would match against all of:
```js
export default {
  validations: {
    schemaPattern: pattern('...'),
    schemaPattern2: pattern('...'),
    schemaPattern3: pattern('...')
    ...etc
  }
}
```

These would be auto generated by my library.

What do you think? Instead of a regexp it could also be a function that gets passed various params like key, messages, vm and need to return true or false depending on if we sould use the message or not.

