### PR TITLE
Typo on singleErrorExtractor

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -39,7 +39,7 @@ you need to go into either `templates.singleErrorExtractor` or `templates.multiE
 ```js
 import VuelidateErrorExtractor, { templates } from 'vuelidate-error-extractor'
 Vue.use(VuelidateErrorExtractor, {
-  template: templates.singleErrorExtractor.foundaton6
+  template: templates.singleErrorExtractor.foundation6
 })
 ```
 


### PR DESCRIPTION
I noticed a little typo on the README.md

The PR fix `singleErrorExtractor.foundaton6` to `singleErrorExtractor.foundation6`

